### PR TITLE
return code '0' when tests fail

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -124,8 +124,7 @@ Promise
     }
 
     console.log(chalk.red('Failed. ❌\n'));
-    /* eslint no-throw-literal: "off" */
-    throw 'lighthouse-ci test failed.';
+    return process.exit(1);
   })
   .catch(err => {
     spinner.stop();


### PR DESCRIPTION
Jenkins somehow doesn't catch the exception thrown in `cli.js`